### PR TITLE
Feat : Spring Cache & EmailCode 생성 및 검증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ dependencies {
 //
 //    //tunneling
 //    implementation 'com.jcraft:jsch:0.1.55'
+    //spring cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 jar {

--- a/src/main/java/com/rtsoju/dku_council_homepage/common/SchedulePetition.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/common/SchedulePetition.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @Slf4j
 @RequiredArgsConstructor
 @Transactional
-public class SchedulePetitionAndCache {
+public class SchedulePetition {
     private final PetitionRepository petitionRepository;
     private final UserRepository userRepository;
     private final CacheService cacheService;
@@ -28,9 +28,9 @@ public class SchedulePetitionAndCache {
         userRepository.bulkPetitionCreateReset();
     }
 
-    @Scheduled(cron = "0 0 0 * * *")
-    public void deleteEmailCodeCache(){
-        log.info("Email Code Cache 삭제");
-        cacheService.expireAllCacheData();
-    }
+//    @Scheduled(cron = "0 0 0 * * *")
+//    public void deleteEmailCodeCache(){
+//        log.info("Email Code Cache 삭제");
+//        cacheService.expireAllCacheData();
+//    }
 }

--- a/src/main/java/com/rtsoju/dku_council_homepage/common/SchedulePetition.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/common/SchedulePetition.java
@@ -1,5 +1,6 @@
 package com.rtsoju.dku_council_homepage.common;
 
+import com.rtsoju.dku_council_homepage.common.cache.CacheService;
 import com.rtsoju.dku_council_homepage.domain.base.PetitionStatus;
 import com.rtsoju.dku_council_homepage.domain.post.repository.PetitionRepository;
 import com.rtsoju.dku_council_homepage.domain.user.repository.UserRepository;
@@ -18,11 +19,18 @@ import java.time.LocalDateTime;
 public class SchedulePetition {
     private final PetitionRepository petitionRepository;
     private final UserRepository userRepository;
+    private final CacheService cacheService;
     @Scheduled(cron = "0 0 0 * * *")
     public void updatePetitionStatus(){
         log.info("Petition상태 없데이트");
         petitionRepository.bulkStatusChange(PetitionStatus.기간만료, LocalDateTime.now().minusDays(15), PetitionStatus.진행중);
         log.info("Petition Create 초기화");
         userRepository.bulkPetitionCreateReset();
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void deleteEmailCodeCache(){
+        log.info("Email Code Cache 삭제");
+        cacheService.expireAllCacheData();
     }
 }

--- a/src/main/java/com/rtsoju/dku_council_homepage/common/SchedulePetitionAndCache.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/common/SchedulePetitionAndCache.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @Slf4j
 @RequiredArgsConstructor
 @Transactional
-public class SchedulePetition {
+public class SchedulePetitionAndCache {
     private final PetitionRepository petitionRepository;
     private final UserRepository userRepository;
     private final CacheService cacheService;

--- a/src/main/java/com/rtsoju/dku_council_homepage/common/cache/CacheData.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/common/cache/CacheData.java
@@ -1,0 +1,11 @@
+package com.rtsoju.dku_council_homepage.common.cache;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class CacheData {
+    private String emailCode;
+    private LocalDateTime expirationDate;
+}

--- a/src/main/java/com/rtsoju/dku_council_homepage/common/cache/CacheService.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/common/cache/CacheService.java
@@ -29,8 +29,12 @@ public class CacheService {
         throw new FindUserWithIdNotFoundException();
     }
 
+    @CacheEvict(cacheNames = "emailCode", key="#studentId")
+    public void expireCacheData(final String studentId){};
+
     @CacheEvict(value = "emailCode", allEntries = true, cacheManager = "cacheManager")
     public void expireAllCacheData(){}
+
 
 
     public boolean isExpired(final CacheData cacheData){

--- a/src/main/java/com/rtsoju/dku_council_homepage/common/cache/CacheService.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/common/cache/CacheService.java
@@ -1,0 +1,39 @@
+package com.rtsoju.dku_council_homepage.common.cache;
+
+import com.rtsoju.dku_council_homepage.exception.FindUserWithIdNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class CacheService {
+
+    @CachePut(cacheNames = "emailCode", key="#studentId")
+    public CacheData createCacheData(final String studentId){
+        CacheData cacheData = new CacheData();
+        cacheData.setEmailCode(UUID.randomUUID().toString().substring(0,5));
+        cacheData.setExpirationDate(LocalDateTime.now().plusMinutes(5));
+        return cacheData;
+    }
+
+    @Cacheable(cacheNames = "emailCode", key="#studentId")
+    public CacheData getCacheData(final String studentId){
+        //하위 로직이 실행되면 Cache에 데이터가 없다는 것.
+        //보통은 생성해서 캐싱해두지만, 우리는 확인을 해야하기에,,,
+        throw new FindUserWithIdNotFoundException();
+    }
+
+    @CacheEvict(value = "emailCode", allEntries = true, cacheManager = "cacheManager")
+    public void expireAllCacheData(){}
+
+
+    public boolean isExpired(final CacheData cacheData){
+        return !cacheData.getExpirationDate().isAfter(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/rtsoju/dku_council_homepage/common/cache/LocalCacheConfig.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/common/cache/LocalCacheConfig.java
@@ -1,0 +1,24 @@
+package com.rtsoju.dku_council_homepage.common.cache;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+@EnableCaching
+@Configuration
+public class LocalCacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(){
+        SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
+        //추후 필요한 경우 여러개의 Cache를 만들 수 있음.
+        simpleCacheManager.setCaches(List.of(new ConcurrentMapCache("emailCode", new ConcurrentHashMap<>(10), false)));
+        return simpleCacheManager;
+    }
+}

--- a/src/main/java/com/rtsoju/dku_council_homepage/common/jwt/JwtProvider.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/common/jwt/JwtProvider.java
@@ -67,7 +67,6 @@ public class JwtProvider {
 
     public String createEmailValidationToken(String classId){
         Claims claims = Jwts.claims();
-//        claims.setSubject("ClassId");
         claims.put("classId",classId);
 
         return createToken(claims, emailTokenValidMillisecond);

--- a/src/main/java/com/rtsoju/dku_council_homepage/domain/auth/email/controller/EmailController.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/domain/auth/email/controller/EmailController.java
@@ -3,14 +3,12 @@ package com.rtsoju.dku_council_homepage.domain.auth.email.controller;
 import com.rtsoju.dku_council_homepage.common.Messages;
 import com.rtsoju.dku_council_homepage.common.ResponseResult;
 import com.rtsoju.dku_council_homepage.common.SuccessResponseResult;
-import com.rtsoju.dku_council_homepage.domain.auth.email.dto.RequestEmailDto;
-import com.rtsoju.dku_council_homepage.domain.auth.email.dto.request.EmailResponseDto;
+import com.rtsoju.dku_council_homepage.domain.auth.email.dto.request.RequestEmailDto;
+import com.rtsoju.dku_council_homepage.domain.auth.email.dto.request.RequestEmailValidationDto;
 import com.rtsoju.dku_council_homepage.domain.auth.email.service.EmailSerivce;
-//import com.rtsoju.dku_council_homepage.domain.auth.email.service.GmailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
-import javax.mail.MessagingException;
 import java.io.IOException;
 
 @Slf4j
@@ -22,15 +20,14 @@ public class EmailController {
     private final EmailSerivce emailSerivce;
 
     @PostMapping("/email")
-    public SuccessResponseResult emailSendForSignUp(@RequestBody RequestEmailDto dto) throws MessagingException, IOException {
-//        gmailService.sendEmailForSignUp(dto);
+    public SuccessResponseResult emailSendForSignUp(@RequestBody RequestEmailDto dto) throws IOException {
         emailSerivce.sendEmailForSignUp(dto);
         log.info("정상적으로 메일을 보냈습니다. 학번 : " + dto.getClassId());
         return new SuccessResponseResult(Messages.SUCCESS_EMAIL_SEND.getMessage());
     }
 
     @PostMapping("/email/password")
-    public SuccessResponseResult emailSendForChangePW(@RequestBody RequestEmailDto dto) throws MessagingException, IOException {
+    public SuccessResponseResult emailSendForChangePW(@RequestBody RequestEmailDto dto) throws IOException {
 //        gmailService.sendEmailForChangePW(dto);
         emailSerivce.sendEmailForChangePW(dto);
         return new SuccessResponseResult(Messages.SUCCESS_EMAIL_SEND.getMessage());
@@ -39,5 +36,17 @@ public class EmailController {
     @GetMapping("/email/validate")
     public ResponseResult validateToken(@RequestParam String token) {
         return new SuccessResponseResult(emailSerivce.validateToken(token));
+    }
+
+    @PostMapping("/m/email")
+    public SuccessResponseResult emailSendForMobileSignUp(@RequestBody RequestEmailDto dto) throws IOException {
+        emailSerivce.sendEmailForMobileSignUp(dto);
+        return new SuccessResponseResult(Messages.SUCCESS_EMAIL_SEND.getMessage());
+    }
+
+    @PostMapping("/m/email/validate")
+    public SuccessResponseResult validateCode(@RequestBody RequestEmailValidationDto dto){
+        String emailToken = emailSerivce.validateEmailCode(dto);
+        return new SuccessResponseResult(Messages.SUCCESS_SMS_AUTH.getMessage(), emailToken);
     }
 }

--- a/src/main/java/com/rtsoju/dku_council_homepage/domain/auth/email/dto/request/RequestEmailDto.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/domain/auth/email/dto/request/RequestEmailDto.java
@@ -1,4 +1,4 @@
-package com.rtsoju.dku_council_homepage.domain.auth.email.dto;
+package com.rtsoju.dku_council_homepage.domain.auth.email.dto.request;
 
 import lombok.Data;
 

--- a/src/main/java/com/rtsoju/dku_council_homepage/domain/auth/email/dto/request/RequestEmailValidationDto.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/domain/auth/email/dto/request/RequestEmailValidationDto.java
@@ -1,0 +1,9 @@
+package com.rtsoju.dku_council_homepage.domain.auth.email.dto.request;
+
+import lombok.Data;
+
+@Data
+public class RequestEmailValidationDto {
+    private String classId;
+    private String code;
+}

--- a/src/main/java/com/rtsoju/dku_council_homepage/domain/auth/email/service/EmailSerivce.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/domain/auth/email/service/EmailSerivce.java
@@ -164,7 +164,7 @@ public class EmailSerivce {
         if(cacheService.isExpired(cacheData)){
             throw new EmailCodeException("인증시간 초과. 재인증 요청바랍니다.");
         }
-        if(dto.getCode().equals(cacheData.getEmailCode())){
+        if(!dto.getCode().equals(cacheData.getEmailCode())){
             throw new EmailCodeException("인증번호가 일치하지 않습니다.");
         }
         return jwtProvider.createEmailValidationToken(dto.getClassId());

--- a/src/main/java/com/rtsoju/dku_council_homepage/domain/auth/email/service/EmailSerivce.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/domain/auth/email/service/EmailSerivce.java
@@ -167,6 +167,8 @@ public class EmailSerivce {
         if(!dto.getCode().equals(cacheData.getEmailCode())){
             throw new EmailCodeException("인증번호가 일치하지 않습니다.");
         }
+        //캐시 삭제
+        cacheService.expireCacheData(dto.getClassId());
         return jwtProvider.createEmailValidationToken(dto.getClassId());
 
 

--- a/src/main/java/com/rtsoju/dku_council_homepage/domain/auth/email/service/GmailService.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/domain/auth/email/service/GmailService.java
@@ -2,7 +2,7 @@
 //
 //import com.rtsoju.dku_council_homepage.common.TextTemplateEngine;
 //import com.rtsoju.dku_council_homepage.common.jwt.JwtProvider;
-//import com.rtsoju.dku_council_homepage.domain.auth.email.dto.RequestEmailDto;
+//import com.rtsoju.dku_council_homepage.domain.auth.email.dto.request.RequestEmailDto;
 //import com.rtsoju.dku_council_homepage.domain.user.service.UserService;
 //import com.rtsoju.dku_council_homepage.exception.ClassIdNotMatchException;
 //import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/rtsoju/dku_council_homepage/domain/user/controller/UserController.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/domain/user/controller/UserController.java
@@ -42,6 +42,14 @@ public class UserController {
         return ResponseEntity.ok().body(new SuccessResponseResult("Sign up Success"));
     }
 
+    @PostMapping("/m/users")
+    public ResponseEntity<SuccessResponseResult> singUpForMobile(@RequestBody RequestSignupDto dto, HttpServletRequest request) {
+        String token = request.getHeader("EMAIL-VALIDATION-TOKEN");
+        Long result = userService.signup(dto, token);
+        log.info("유저가 회원가입을 하였습니다. 학번: " + dto.getClassId());
+        return ResponseEntity.ok().body(new SuccessResponseResult("Sign up Success"));
+    }
+
 
     @PostMapping("/users/login")
     public ResponseEntity<SuccessResponseResult> login(@RequestBody RequestLoginDto dto) {

--- a/src/main/java/com/rtsoju/dku_council_homepage/domain/user/model/dto/request/RequestSignupDto.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/domain/user/model/dto/request/RequestSignupDto.java
@@ -11,11 +11,8 @@ public class RequestSignupDto {
     private String classId;
     private String password;
     private String name;
-
-
     private Major major;
     private Register register;
-
     private String phone;
 
 

--- a/src/main/java/com/rtsoju/dku_council_homepage/exception/EmailCodeException.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/exception/EmailCodeException.java
@@ -1,0 +1,15 @@
+package com.rtsoju.dku_council_homepage.exception;
+
+public class EmailCodeException extends RuntimeException{
+    public EmailCodeException() {
+        super("인증시간이 만료되었습니다.");
+    }
+
+    public EmailCodeException(String message) {
+        super(message);
+    }
+
+    public EmailCodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/resources/auth_email_content_mobile.html
+++ b/src/main/resources/auth_email_content_mobile.html
@@ -1,0 +1,353 @@
+<xlink
+        href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700"
+        rel="stylesheet"
+        type="text/css"
+>
+    <div style="background-color: #f9f9f9">
+        <div
+                style="
+        max-width: 640px;
+        margin: 0 auto;
+        box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.1);
+        border-radius: 4px;
+        overflow: hidden;
+      "
+        >
+            <div style="margin: 0px auto; max-width: 640px; background: #ffffff">
+                <table
+                        align="center"
+                        cellpadding="0"
+                        cellspacing="0"
+                        style="font-size: 0px; width: 100%; background: #ffffff"
+                        border="0"
+                >
+                    <tbody>
+                    <tr>
+                        <td
+                                style="
+                  text-align: center;
+                  vertical-align: top;
+                  direction: ltr;
+                  font-size: 0px;
+                  padding: 40px 50px;
+                "
+                        >
+                            <div
+                                    style="
+                    vertical-align: top;
+                    display: inline-block;
+                    direction: ltr;
+                    font-size: 13px;
+                    text-align: left;
+                    width: 100%;
+                  "
+                            >
+                                <table
+                                        cellpadding="0"
+                                        cellspacing="0"
+                                        width="100%"
+                                        border="0"
+                                >
+                                    <tbody>
+                                    <tr>
+                                        <td
+                                                align="left"
+                                                style="
+                            word-break: break-word;
+                            font-size: 0px;
+                            padding: 0px;
+                          "
+                                        >
+                                            <div
+                                                    style="
+                              cursor: auto;
+                              color: #737f8d;
+                              font-family: Whitney, Helvetica Neue, Helvetica,
+                                Arial, Lucida Grande, sans-serif;
+                              font-size: 16px;
+                              line-height: 24px;
+                              text-align: left;
+                            "
+                                            >
+                                                <h2
+                                                        style="
+                                font-family: Whitney, Helvetica Neue, Helvetica,
+                                  Arial, Lucida Grande, sans-serif;
+                                font-weight: 500;
+                                font-size: 20px;
+                                color: #4f545c;
+                                letter-spacing: 0.27px;
+                              "
+                                                >
+                                                    안녕하세요!
+                                                </h2>
+                                                <p>
+                                                    @{emailContent}
+                                                    <br/>
+                                                    만약 내가 보낸 링크가 아니라면, 아래의 이메일로
+                                                    문의 해 주세요.
+                                                </p>
+                                                <p>
+                                                    <strong>학번:</strong>
+                                                    @{studentId}<br/>
+                                                </p>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td
+                                                align="center"
+                                                style="
+                            word-break: break-word;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            padding-top: 20px;
+                          "
+                                        >
+                                            <table
+                                                    align="center"
+                                                    cellpadding="0"
+                                                    cellspacing="0"
+                                                    style="border-collapse: separate"
+                                                    border="0"
+                                            >
+                                                <tbody>
+                                                <tr>
+                                                    <td
+                                                            align="center"
+                                                            valign="middle"
+                                                            style="
+                                    border: none;
+                                    border-radius: 9999px;
+                                    color: white;
+                                    cursor: auto;
+                                    padding: 15px 19px;
+                                  "
+                                                            bgcolor="#1C4991"
+                                                    >
+                                                        <p
+                                                                style="
+                                      text-decoration: none;
+                                      line-: 100%;
+                                      background: #1c4991;
+                                      color: white;
+                                      font-family: ubuntu, helvetica, arial,
+                                        sans-serif;
+                                      font-size: 15px;
+                                      font-weight: normal;
+                                      text-transform: none;
+                                      margin: 0px;
+                                    "
+                                                                target="_blank"
+                                                                rel="noreferrer noopener"
+                                                        >
+                                                            @{linkButtonContent}
+                                                        </p>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td
+                                                style="
+                            word-break: break-word;
+                            font-size: 0px;
+                            padding: 30px 0px;
+                          "
+                                        >
+                                            <p
+                                                    style="
+                              font-size: 1px;
+                              margin: 0px auto;
+                              border-top: 1px solid #dcddde;
+                              width: 100%;
+                            "
+                                            ></p>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td
+                                                align="left"
+                                                style="
+                            word-break: break-word;
+                            font-size: 0px;
+                            padding: 0px;
+                          "
+                                        >
+                                            <div
+                                                    style="
+                              cursor: auto;
+                              color: #747f8d;
+                              font-family: Whitney, Helvetica Neue, Helvetica,
+                                Arial, Lucida Grande, sans-serif;
+                              font-size: 13px;
+                              line-height: 16px;
+                              text-align: left;
+                            "
+                                            >
+                                                <p>
+                                                    도움이 필요하거나 피드백을 주고 싶나요?
+                                                    <strong>ho991217@kakao.com</strong> 으로 문의
+                                                    해주세요.<br/>
+                                                </p>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <!--[if mso | IE]>
+                            </td></tr></table>
+                            <![endif]-->
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+            <!--[if mso | IE]>
+            </div></td></tr></table>
+            <![endif]-->
+            <!--[if mso | IE]>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" width="640" style="width:640px;">
+                <tr>
+                    <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+            <![endif]-->
+            <div style="margin: 0px auto; max-width: 640px; background: transparent">
+                <table
+                        align="center"
+                        cellpadding="0"
+                        cellspacing="0"
+                        style="font-size: 0px; width: 100%; background: transparent"
+                        border="0"
+                >
+                    <tbody>
+                    <tr>
+                        <td
+                                style="
+                  text-align: center;
+                  vertical-align: top;
+                  direction: ltr;
+                  font-size: 0px;
+                  padding: 20px 0px;
+                "
+                        >
+                            <!--[if mso | IE]>
+                            <table border="0" cellpadding="0" cellspacing="0">
+                                <tr>
+                                    <td style="vertical-align:top;width:640px;">
+                            <![endif]-->
+                            <div
+                                    style="
+                    vertical-align: top;
+                    display: inline-block;
+                    direction: ltr;
+                    font-size: 13px;
+                    text-align: left;
+                    width: 100%;
+                  "
+                            >
+                                <table
+                                        cellpadding="0"
+                                        cellspacing="0"
+                                        width="100%"
+                                        border="0"
+                                >
+                                    <tbody>
+                                    <tr>
+                                        <td
+                                                align="center"
+                                                style="
+                            word-break: break-word;
+                            font-size: 0px;
+                            padding: 0px;
+                          "
+                                        >
+                                            <div
+                                                    style="
+                              cursor: auto;
+                              color: #99aab5;
+                              font-family: Whitney, Helvetica Neue, Helvetica,
+                                Arial, Lucida Grande, sans-serif;
+                              font-size: 12px;
+                              line-height: 24px;
+                              text-align: center;
+                            "
+                                            >
+                                                • 단국대학교 총학생회에서 보냄 •
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td
+                                                align="center"
+                                                style="
+                            word-break: break-word;
+                            font-size: 0px;
+                            padding: 0px;
+                          "
+                                        >
+                                            <div
+                                                    style="
+                              cursor: auto;
+                              color: #99aab5;
+                              font-family: Whitney, Helvetica Neue, Helvetica,
+                                Arial, Lucida Grande, sans-serif;
+                              font-size: 12px;
+                              line-height: 24px;
+                              text-align: center;
+                            "
+                                            >
+                                                경기도 용인시 수지구 죽전동 1491 단국대학교 혜당관
+                                                406호 총학생회실
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td
+                                                align="left"
+                                                style="
+                            word-break: break-word;
+                            font-size: 0px;
+                            padding: 0px;
+                          "
+                                        >
+                                            <div
+                                                    style="
+                              cursor: auto;
+                              color: #000000;
+                              font-family: Whitney, Helvetica Neue, Helvetica,
+                                Arial, Lucida Grande, sans-serif;
+                              font-size: 13px;
+                              line-height: 22px;
+                              text-align: left;
+                            "
+                                            >
+                                                <img
+                                                        src="https://discord.com/api/science/396548344136204292/e316c278-8a45-41c2-998f-c0650ab44649.gif?properties=eyJlbWFpbF90eXBlIjogInVzZXJfaXBfYXV0aG9yaXplIn0%3D"
+                                                        width="1"
+                                                        height="1"
+                                                        loading="lazy"
+                                                />
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <!--[if mso | IE]>
+                            </td></tr></table>
+                            <![endif]-->
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+            <!--[if mso | IE]>
+            </td></tr></table></div>
+            <![endif]-->
+        </div>
+    </div
+    >
+</xlink>

--- a/src/test/java/com/rtsoju/dku_council_homepage/common/cache/CacheServiceTest.java
+++ b/src/test/java/com/rtsoju/dku_council_homepage/common/cache/CacheServiceTest.java
@@ -27,5 +27,14 @@ class CacheServiceTest {
         //없는데 조회
         assertThrows(FindUserWithIdNotFoundException.class, () -> cacheService.getCacheData("1234"));
 
+        //생성
+        CacheData cacheData2 = cacheService.createCacheData("1234");
+        CacheData cacheData3 = cacheService.getCacheData("1234");
+        assertEquals(cacheData2, cacheData3);
+
+        //삭제
+        cacheService.expireCacheData("1234");
+
+        assertThrows(FindUserWithIdNotFoundException.class, () -> cacheService.getCacheData("1234"));
     }
 }

--- a/src/test/java/com/rtsoju/dku_council_homepage/common/cache/CacheServiceTest.java
+++ b/src/test/java/com/rtsoju/dku_council_homepage/common/cache/CacheServiceTest.java
@@ -1,0 +1,31 @@
+package com.rtsoju.dku_council_homepage.common.cache;
+
+import com.rtsoju.dku_council_homepage.exception.FindUserWithIdNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+class CacheServiceTest {
+    @Autowired private CacheService cacheService;
+
+    @Test
+    public void test(){
+
+        //Cache 생성
+        CacheData cacheData = cacheService.createCacheData("1234");
+        assertEquals(cacheData, cacheService.getCacheData("1234"));
+
+        //Cache 업데이트
+        CacheData cacheData1 = cacheService.createCacheData("1234");
+        assertNotEquals(cacheData, cacheData1);
+
+        //Cache 삭제
+        cacheService.expireAllCacheData();
+
+        //없는데 조회
+        assertThrows(FindUserWithIdNotFoundException.class, () -> cacheService.getCacheData("1234"));
+
+    }
+}


### PR DESCRIPTION
## Spring Cache

Key, Value 형식으로 저장했습니다.
- Key : studentId <학번>
- Value : CacheData -> emailCode 및 만료시간이 담겨있습니다.

@CachePut -> 이메일 인증 코드 및 만료시간을 5분으로 설정하였습니다.

@Cacheable -> Cache를 생성 및 조회하는 어노테이션인데, 기존에 값이 없다면 생성하기에 이를 이용하여 기존에 값이 없는 경우 throw Exception으로 에러 처리를 하였습니다. 값이 존재할 경우 Cache에서 반환합니다.

@CacheEvict -> Scheduler에 등록하여 자정마다 Cache를 삭제합니다. (SchedulePetition -> SchedulePetitionAndCache 이름변경)
*이렇게 설정한 이유는, @CachePut이 Update 역할을 해주기에 요청마다 값이 갱신됩니다.*

---

**모바일 API 경로를 api/m/~~ 로 통일하였습니다.**

---

**기존 API를 활용하기 위한 EmailValidationToken생성**
<img width="727" alt="image" src="https://user-images.githubusercontent.com/78069223/213608114-b99d7c28-f89a-4c1d-8c43-a779735060b5.png">

기존에 사용하던 회원가입 API를 그대로 사용하기 위해 EmailCode가 일치할 경우 Token을 발급하였습니다. <SuccessResponse>에 data로 담았습니다.
Client에서 Header에 "EMAIL-VALIDATION-TOKEN"으로 세팅하면 기존 API를 그대로 사용할 수 있습니다.

